### PR TITLE
fix: 🐛 Correct package name from "Cereberus" to "Cerebrus"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Cereberus",
+  "name": "Cerebrus",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
* Fixed a typo in the package name in `package-lock.json`.