### PR TITLE
303 configuración de comportamiento post actividad frontend

### DIFF
--- a/backend/src/main/java/com/cerebrus/actividad/tablero/TableroServiceImpl.java
+++ b/backend/src/main/java/com/cerebrus/actividad/tablero/TableroServiceImpl.java
@@ -11,14 +11,14 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.cerebrus.comun.enumerados.TamanoTablero;
-import com.cerebrus.comun.utils.AccesoActividadAlumnoUtils;
 import com.cerebrus.actividad.ActividadRepository;
 import com.cerebrus.actividad.tablero.dto.TableroDTO;
 import com.cerebrus.actividad.tablero.dto.TableroRequest;
 import com.cerebrus.actividadAlumn.ActividadAlumno;
 import com.cerebrus.actividadAlumn.ActividadAlumnoRepository;
 import com.cerebrus.actividadAlumn.ActividadAlumnoService;
+import com.cerebrus.comun.enumerados.TamanoTablero;
+import com.cerebrus.comun.utils.AccesoActividadAlumnoUtils;
 import com.cerebrus.exceptions.ResourceNotFoundException;
 import com.cerebrus.inscripcion.Inscripcion;
 import com.cerebrus.pregunta.Pregunta;
@@ -246,8 +246,13 @@ public class TableroServiceImpl implements TableroService {
             if (respuestaAlumnoExistente != null) {
                 respuestaAlumnoExistente.setRespuesta(respuesta);
                 respuestaAlumnoExistente.setCorrecta(correcta);
+                if (respuestaAlumnoExistente instanceof RespAlumnoGeneral respAlumnoGeneralExistente && !correcta) {
+                    int fallosPrevios = java.util.Objects.requireNonNullElse(respAlumnoGeneralExistente.getNumFallos(), 0);
+                    respAlumnoGeneralExistente.setNumFallos(fallosPrevios + 1);
+                }
             } else {
                 RespAlumnoGeneral respuestaAlumnoNueva = new RespAlumnoGeneral(correcta, actividadAlumno, respuesta, pregunta);
+                respuestaAlumnoNueva.setNumFallos(Boolean.TRUE.equals(correcta) ? 0 : 1);
                 actividadAlumno.getRespuestasAlumno().add(respuestaAlumnoNueva);
             }
 
@@ -263,20 +268,16 @@ public class TableroServiceImpl implements TableroService {
 
             if (preguntasCorrectasUnicas.size() == tablero.getPreguntas().size()) {
                 actividadAlumno.setFechaFin(LocalDateTime.now());
-                int numErrores = 0;
-                for(RespuestaAlumno resp : actividadAlumno.getRespuestasAlumno()) {
-                    if(!resp.getCorrecta()) {
-                        numErrores++;
+                int numFallosTotales = 0;
+                for (RespuestaAlumno resp : actividadAlumno.getRespuestasAlumno()) {
+                    if (resp instanceof RespAlumnoGeneral respGeneral) {
+                        numFallosTotales += java.util.Objects.requireNonNullElse(respGeneral.getNumFallos(), 0);
                     }
                 }
-                Integer notaFinal = Math.round(10 - (numErrores * (10 / tablero.getPreguntas().size()/4)));
-                if (notaFinal <= 0) {
-                    notaFinal = 1;
-                }
-                Integer puntuacionFinal = Math.round(tablero.getPuntuacion() - (numErrores * (tablero.getPuntuacion() / tablero.getPreguntas().size()/4)));
-                if (puntuacionFinal <= 0) {
-                    puntuacionFinal = 1;
-                }
+
+                int notaFinal = Math.max(0, 10 - numFallosTotales);
+                Integer puntuacionBase = java.util.Objects.requireNonNullElse(tablero.getPuntuacion(), 0);
+                Integer puntuacionFinal = (int) Math.round(puntuacionBase.doubleValue() * (notaFinal / 10.0));
                 actividadAlumno.setNota(notaFinal);
                 actividadAlumno.setPuntuacion(puntuacionFinal);
             }

--- a/backend/src/main/java/com/cerebrus/actividadAlumn/ActividadAlumno.java
+++ b/backend/src/main/java/com/cerebrus/actividadAlumn/ActividadAlumno.java
@@ -5,6 +5,11 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.cerebrus.actividad.Actividad;
+import com.cerebrus.comun.enumerados.EstadoActividad;
+import com.cerebrus.respuestaAlumn.RespuestaAlumno;
+import com.cerebrus.usuario.alumno.Alumno;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -18,11 +23,6 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-
-import com.cerebrus.actividad.Actividad;
-import com.cerebrus.comun.enumerados.EstadoActividad;
-import com.cerebrus.respuestaAlumn.RespuestaAlumno;
-import com.cerebrus.usuario.alumno.Alumno;
 
 @Entity
 @Table(name = "actividad_alumno")
@@ -144,6 +144,15 @@ public class ActividadAlumno {
         if (fechaFin.isBefore(fechaInicio)) return 0;
         long minutos = ChronoUnit.MINUTES.between(fechaInicio, fechaFin);
         return (int) minutos;
+    }
+
+    public Integer getTiempoSegundos() {
+        LocalDateTime epoch = LocalDateTime.of(1970, 1, 1, 0, 0);
+        if (fechaInicio == null || fechaFin == null) return 0;
+        if (fechaInicio.equals(epoch) || fechaFin.equals(epoch)) return 0;
+        if (fechaFin.isBefore(fechaInicio)) return 0;
+        long segundos = ChronoUnit.SECONDS.between(fechaInicio, fechaFin);
+        return (int) segundos;
     }
 
     public Integer getNumRepeticiones(){

--- a/backend/src/main/java/com/cerebrus/actividadAlumn/ActividadAlumnoServiceImpl.java
+++ b/backend/src/main/java/com/cerebrus/actividadAlumn/ActividadAlumnoServiceImpl.java
@@ -351,18 +351,9 @@ public class ActividadAlumnoServiceImpl implements ActividadAlumnoService {
             if (preguntaCorrecta) {
                 puntuacionAcumulada += valorPuntoPorPregunta;
                 notaAcumulada += valorNotaPorPregunta;
-            } else {
-                puntuacionAcumulada -= valorPuntoPorPregunta / 2;
-                notaAcumulada -= valorNotaPorPregunta / 2;
             }
         }
 
-        if(puntuacionAcumulada < 0) {
-            puntuacionAcumulada = 0;
-        }
-        if(notaAcumulada < 0) {
-            notaAcumulada = 0;
-        }
         actividadAlumno.setPuntuacion((int) Math.round(puntuacionAcumulada));
         actividadAlumno.setNota((int) Math.round(notaAcumulada));
         actividadAlumno.setFechaFin(LocalDateTime.now());

--- a/backend/src/main/java/com/cerebrus/actividadAlumn/ActividadAlumnoServiceImpl.java
+++ b/backend/src/main/java/com/cerebrus/actividadAlumn/ActividadAlumnoServiceImpl.java
@@ -21,6 +21,7 @@ import com.cerebrus.actividad.marcarImagen.MarcarImagen;
 import com.cerebrus.actividad.marcarImagen.MarcarImagenService;
 import com.cerebrus.actividad.ordenacion.Ordenacion;
 import com.cerebrus.actividad.ordenacion.OrdenacionService;
+import com.cerebrus.actividad.tablero.Tablero;
 import com.cerebrus.comun.enumerados.EstadoActividad;
 import com.cerebrus.comun.enumerados.TipoActGeneral;
 import com.cerebrus.comun.utils.AccesoActividadAlumnoUtils;
@@ -268,6 +269,8 @@ public class ActividadAlumnoServiceImpl implements ActividadAlumnoService {
             corregirActAlumnoAutomaticamenteTipoOrdenacion(actividadAlumno, respuestasIds, actividad);
         } else if(actividad instanceof MarcarImagen){
             corregirActAlumnoAutomaticamenteTipoMarcarImagen(actividadAlumno, respuestasIds, actividad);
+        } else if (actividad instanceof Tablero) {
+            corregirActAlumnoAutomaticamenteTipoTablero(actividadAlumno, actividad);
         } else {    
         // CASO PARA TEORÍA: se ha movido dentro de instancia de GENERAL porque la actividad de teoria es una actividad general
         }
@@ -517,6 +520,22 @@ public class ActividadAlumnoServiceImpl implements ActividadAlumnoService {
 
         actividadAlumno.setPuntuacion(puntuacionFinal);
         actividadAlumno.setNota(notaFinal);
+    }
+
+    private void corregirActAlumnoAutomaticamenteTipoTablero(ActividadAlumno actividadAlumno, Actividad actividad) {
+        int puntuacionMaxima = actividad.getPuntuacion() != null ? actividad.getPuntuacion() : 0;
+        int numFallosTotales = actividadAlumno.getRespuestasAlumno().stream()
+            .filter(RespAlumnoGeneral.class::isInstance)
+            .map(RespAlumnoGeneral.class::cast)
+            .mapToInt(resp -> java.util.Objects.requireNonNullElse(resp.getNumFallos(), 0))
+            .sum();
+
+        int notaFinal = Math.max(0, 10 - numFallosTotales);
+        int puntuacionFinal = (int) Math.round(puntuacionMaxima * (notaFinal / 10.0));
+
+        actividadAlumno.setPuntuacion(puntuacionFinal);
+        actividadAlumno.setNota(notaFinal);
+        actividadAlumno.setFechaFin(LocalDateTime.now());
     }
 
     private void corregirActAlumnoAutomaticamenteTipoCrucigrama(ActividadAlumno actividadAlumno, Actividad actividad) {

--- a/backend/src/main/java/com/cerebrus/estadisticas/EstadisticasMaestroServiceImpl.java
+++ b/backend/src/main/java/com/cerebrus/estadisticas/EstadisticasMaestroServiceImpl.java
@@ -26,8 +26,6 @@ import com.cerebrus.comun.enumerados.EstadoActividad;
 import com.cerebrus.curso.Curso;
 import com.cerebrus.curso.CursoRepository;
 import com.cerebrus.estadisticas.dto.ActividadEstadisticasAlumnoDTO;
-import com.cerebrus.estadisticas.dto.IntentoActividadDetalleDTO;
-import com.cerebrus.estadisticas.dto.IntentoDetalleRespuestaDTO;
 import com.cerebrus.estadisticas.dto.AlumnosMasRapidosLentosDTO;
 import com.cerebrus.estadisticas.dto.EstadisticasActividadDTO;
 import com.cerebrus.estadisticas.dto.EstadisticasAlumnoDTO;
@@ -35,9 +33,11 @@ import com.cerebrus.estadisticas.dto.EstadisticasAlumnoResumenDTO;
 import com.cerebrus.estadisticas.dto.EstadisticasCursoDTO;
 import com.cerebrus.estadisticas.dto.EstadisticasTemaDTO;
 import com.cerebrus.estadisticas.dto.IntentoActividadDTO;
+import com.cerebrus.estadisticas.dto.IntentoActividadDetalleDTO;
+import com.cerebrus.estadisticas.dto.IntentoDetalleRespuestaDTO;
+import com.cerebrus.estadisticas.dto.RepeticionesActividadDTO;
 import com.cerebrus.estadisticas.dto.TemaEstadisticasAlumnoDTO;
 import com.cerebrus.estadisticas.dto.TiempoAlumnoDTO;
-import com.cerebrus.estadisticas.dto.RepeticionesActividadDTO;
 import com.cerebrus.inscripcion.Inscripcion;
 import com.cerebrus.respuestaAlumn.RespuestaAlumno;
 import com.cerebrus.respuestaAlumn.respAlumGeneral.RespAlumnoGeneral;
@@ -1271,7 +1271,7 @@ public class EstadisticasMaestroServiceImpl implements EstadisticasMaestroServic
 
     private IntentoDetalleRespuestaDTO mapearRespuestaIntento(RespuestaAlumno respuestaAlumno) {
         if (respuestaAlumno == null) {
-            return new IntentoDetalleRespuestaDTO(null, "OTRO", "Respuesta", "", null);
+            return new IntentoDetalleRespuestaDTO(null, "OTRO", "Respuesta", "", null, null);
         }
 
         if (respuestaAlumno instanceof RespAlumnoGeneral rag) {
@@ -1293,7 +1293,8 @@ public class EstadisticasMaestroServiceImpl implements EstadisticasMaestroServic
                     "GENERAL",
                     enunciado,
                     rag.getRespuesta(),
-                    correcta);
+                    correcta,
+                    rag.getNumFallos());
         }
         if (respuestaAlumno instanceof RespAlumnoPuntoImagen rpi) {
             String respuestaCorrecta = (rpi.getPuntoImagen() != null && rpi.getPuntoImagen().getRespuesta() != null)
@@ -1307,7 +1308,8 @@ public class EstadisticasMaestroServiceImpl implements EstadisticasMaestroServic
                     "PUNTO_IMAGEN",
                     enunciado,
                     rpi.getRespuesta(),
-                    rpi.getCorrecta());
+                    rpi.getCorrecta(),
+                    null);
         }
         if (respuestaAlumno instanceof RespAlumnoOrdenacion rao) {
             String enunciado = "Ordenacion";
@@ -1317,7 +1319,8 @@ public class EstadisticasMaestroServiceImpl implements EstadisticasMaestroServic
                     "ORDENACION",
                     enunciado,
                     valor,
-                    rao.getCorrecta());
+                    rao.getCorrecta(),
+                    null);
         }
 
         return new IntentoDetalleRespuestaDTO(
@@ -1325,7 +1328,8 @@ public class EstadisticasMaestroServiceImpl implements EstadisticasMaestroServic
                 "OTRO",
                 "Respuesta",
                 "",
-                respuestaAlumno.getCorrecta());
+                respuestaAlumno.getCorrecta(),
+                null);
     }
 
     private Integer calcularNotaDesdePuntuacion(Integer puntuacion, Integer puntuacionMaximaActividad) {

--- a/backend/src/main/java/com/cerebrus/estadisticas/EstadisticasMaestroServiceImpl.java
+++ b/backend/src/main/java/com/cerebrus/estadisticas/EstadisticasMaestroServiceImpl.java
@@ -39,6 +39,7 @@ import com.cerebrus.estadisticas.dto.RepeticionesActividadDTO;
 import com.cerebrus.estadisticas.dto.TemaEstadisticasAlumnoDTO;
 import com.cerebrus.estadisticas.dto.TiempoAlumnoDTO;
 import com.cerebrus.inscripcion.Inscripcion;
+import com.cerebrus.pregunta.Pregunta;
 import com.cerebrus.respuestaAlumn.RespuestaAlumno;
 import com.cerebrus.respuestaAlumn.respAlumGeneral.RespAlumnoGeneral;
 import com.cerebrus.respuestaAlumn.respAlumOrdenacion.RespAlumnoOrdenacion;
@@ -828,6 +829,7 @@ public class EstadisticasMaestroServiceImpl implements EstadisticasMaestroServic
                                 aa.getPuntuacion(),
                                 aa.getNota(),
                                 aa.getTiempoMinutos(),
+                                aa.getTiempoSegundos(),
                                 aa.getNumAbandonos()))
                         .toList();
 
@@ -860,6 +862,18 @@ public class EstadisticasMaestroServiceImpl implements EstadisticasMaestroServic
                 : notasAlumno.stream().mapToInt(Integer::intValue).min().orElse(0);
         Integer notaMax = notasAlumno.isEmpty() ? null
                 : notasAlumno.stream().mapToInt(Integer::intValue).max().orElse(0);
+        Integer tiempoTotalSegundos = 0;
+        for (Tema tema : curso.getTemas()) {
+            for (Actividad actividad : tema.getActividades()) {
+                ActividadAlumno ultimaTerminada = obtenerUltimasInstanciasPorAlumno(actividad.getActividadesAlumno()).stream()
+                        .filter(aa -> aa.getAlumno().getId().equals(alumnoId) && aa.getEstadoActividad() == EstadoActividad.TERMINADA)
+                        .findFirst()
+                        .orElse(null);
+                if (ultimaTerminada != null && ultimaTerminada.getTiempoSegundos() != null) {
+                    tiempoTotalSegundos += ultimaTerminada.getTiempoSegundos();
+                }
+            }
+        }
 
         return new EstadisticasAlumnoResumenDTO(
                 alumnoId,
@@ -870,6 +884,7 @@ public class EstadisticasMaestroServiceImpl implements EstadisticasMaestroServic
                 actividadesCompletadas,
                 totalActividades,
                 tiempoTotal,
+                tiempoTotalSegundos,
                 temasDTO);
     }
 
@@ -916,6 +931,7 @@ public class EstadisticasMaestroServiceImpl implements EstadisticasMaestroServic
             intento.getFechaInicio(),
             intento.getFechaFin(),
             intento.getTiempoMinutos(),
+            intento.getTiempoSegundos(),
             intento.getPuntuacion(),
             intento.getNota(),
             intento.getNumAbandonos(),
@@ -969,6 +985,7 @@ public class EstadisticasMaestroServiceImpl implements EstadisticasMaestroServic
             intento.getPuntuacion(),
             intento.getNota(),
             intento.getTiempoMinutos(),
+            intento.getTiempoSegundos(),
             intento.getNumAbandonos());
     }
 
@@ -1275,17 +1292,28 @@ public class EstadisticasMaestroServiceImpl implements EstadisticasMaestroServic
         }
 
         if (respuestaAlumno instanceof RespAlumnoGeneral rag) {
-            String enunciado = rag.getPregunta() != null ? rag.getPregunta().getPregunta() : "Pregunta";
+            String enunciado = "Pregunta";
             Boolean correcta = rag.getCorrecta();
 
-            if (rag.getPregunta() != null && rag.getPregunta().getActividad() instanceof General general
-                && general.getTipo() == com.cerebrus.comun.enumerados.TipoActGeneral.CLASIFICACION
-                && rag.getRespuesta() != null) {
-                correcta = respuestaMaestroRepository.findByRespuesta(rag.getRespuesta())
-                    .map(RespuestaMaestro::getPregunta)
-                    .filter(preguntaMaestra -> preguntaMaestra != null && preguntaMaestra.getId() != null)
-                    .map(preguntaMaestra -> preguntaMaestra.getId().equals(rag.getPregunta().getId()))
-                    .orElse(Boolean.FALSE);
+            try {
+                // Try to load the Pregunta - it might not exist if deleted
+                Pregunta pregunta = rag.getPregunta();
+                if (pregunta != null) {
+                    enunciado = pregunta.getPregunta();
+
+                    if (pregunta.getActividad() instanceof General general
+                        && general.getTipo() == com.cerebrus.comun.enumerados.TipoActGeneral.CLASIFICACION
+                        && rag.getRespuesta() != null) {
+                        correcta = respuestaMaestroRepository.findByRespuesta(rag.getRespuesta())
+                            .map(RespuestaMaestro::getPregunta)
+                            .filter(preguntaMaestra -> preguntaMaestra != null && preguntaMaestra.getId() != null)
+                            .map(preguntaMaestra -> preguntaMaestra.getId().equals(pregunta.getId()) ? Boolean.TRUE : Boolean.FALSE)
+                            .orElse(Boolean.FALSE);
+                    }
+                }
+            } catch (jakarta.persistence.EntityNotFoundException e) {
+                // Pregunta doesn't exist - use default enunciado
+                log.warn("Pregunta not found for RespAlumnoGeneral ID: {}", rag.getId());
             }
 
             return new IntentoDetalleRespuestaDTO(

--- a/backend/src/main/java/com/cerebrus/estadisticas/dto/EstadisticasAlumnoResumenDTO.java
+++ b/backend/src/main/java/com/cerebrus/estadisticas/dto/EstadisticasAlumnoResumenDTO.java
@@ -12,13 +12,14 @@ public class EstadisticasAlumnoResumenDTO {
     private Integer numActividadesCompletadas;
     private Integer totalActividades;
     private Integer tiempoTotalMinutos;
+    private Integer tiempoTotalSegundos;
     private List<TemaEstadisticasAlumnoDTO> temas;
 
     public EstadisticasAlumnoResumenDTO() {}
 
     public EstadisticasAlumnoResumenDTO(Long alumnoId, String nombreAlumno, Double notaMedia,
             Integer notaMin, Integer notaMax, Integer numActividadesCompletadas,
-            Integer totalActividades, Integer tiempoTotalMinutos,
+            Integer totalActividades, Integer tiempoTotalMinutos, Integer tiempoTotalSegundos,
             List<TemaEstadisticasAlumnoDTO> temas) {
         this.alumnoId = alumnoId;
         this.nombreAlumno = nombreAlumno;
@@ -28,6 +29,7 @@ public class EstadisticasAlumnoResumenDTO {
         this.numActividadesCompletadas = numActividadesCompletadas;
         this.totalActividades = totalActividades;
         this.tiempoTotalMinutos = tiempoTotalMinutos;
+        this.tiempoTotalSegundos = tiempoTotalSegundos;
         this.temas = temas;
     }
 
@@ -47,6 +49,8 @@ public class EstadisticasAlumnoResumenDTO {
     public void setTotalActividades(Integer totalActividades) { this.totalActividades = totalActividades; }
     public Integer getTiempoTotalMinutos() { return tiempoTotalMinutos; }
     public void setTiempoTotalMinutos(Integer tiempoTotalMinutos) { this.tiempoTotalMinutos = tiempoTotalMinutos; }
+    public Integer getTiempoTotalSegundos() { return tiempoTotalSegundos; }
+    public void setTiempoTotalSegundos(Integer tiempoTotalSegundos) { this.tiempoTotalSegundos = tiempoTotalSegundos; }
     public List<TemaEstadisticasAlumnoDTO> getTemas() { return temas; }
     public void setTemas(List<TemaEstadisticasAlumnoDTO> temas) { this.temas = temas; }
 }

--- a/backend/src/main/java/com/cerebrus/estadisticas/dto/IntentoActividadDTO.java
+++ b/backend/src/main/java/com/cerebrus/estadisticas/dto/IntentoActividadDTO.java
@@ -10,18 +10,20 @@ public class IntentoActividadDTO {
     private Integer puntuacion;
     private Integer nota;
     private Integer tiempoMinutos;
+    private Integer tiempoSegundos;
     private Integer numAbandonos;
 
     public IntentoActividadDTO() {}
 
     public IntentoActividadDTO(Long id, LocalDateTime fechaInicio, LocalDateTime fechaFin,
-            Integer puntuacion, Integer nota, Integer tiempoMinutos, Integer numAbandonos) {
+            Integer puntuacion, Integer nota, Integer tiempoMinutos, Integer tiempoSegundos, Integer numAbandonos) {
         this.id = id;
         this.fechaInicio = fechaInicio;
         this.fechaFin = fechaFin;
         this.puntuacion = puntuacion;
         this.nota = nota;
         this.tiempoMinutos = tiempoMinutos;
+        this.tiempoSegundos = tiempoSegundos;
         this.numAbandonos = numAbandonos;
     }
 
@@ -37,6 +39,8 @@ public class IntentoActividadDTO {
     public void setNota(Integer nota) { this.nota = nota; }
     public Integer getTiempoMinutos() { return tiempoMinutos; }
     public void setTiempoMinutos(Integer tiempoMinutos) { this.tiempoMinutos = tiempoMinutos; }
+    public Integer getTiempoSegundos() { return tiempoSegundos; }
+    public void setTiempoSegundos(Integer tiempoSegundos) { this.tiempoSegundos = tiempoSegundos; }
     public Integer getNumAbandonos() { return numAbandonos; }
     public void setNumAbandonos(Integer numAbandonos) { this.numAbandonos = numAbandonos; }
 }

--- a/backend/src/main/java/com/cerebrus/estadisticas/dto/IntentoActividadDetalleDTO.java
+++ b/backend/src/main/java/com/cerebrus/estadisticas/dto/IntentoActividadDetalleDTO.java
@@ -16,6 +16,7 @@ public class IntentoActividadDetalleDTO {
     private LocalDateTime fechaInicio;
     private LocalDateTime fechaFin;
     private Integer tiempoMinutos;
+    private Integer tiempoSegundos;
     private Integer puntuacion;
     private Integer nota;
     private Integer numAbandonos;
@@ -25,7 +26,7 @@ public class IntentoActividadDetalleDTO {
 
     public IntentoActividadDetalleDTO(Long intentoId, Long cursoId, Long alumnoId, Long actividadId,
             String actividadTitulo, String actividadTipo, String actividadImagen, Integer puntuacionMaxima,
-            LocalDateTime fechaInicio, LocalDateTime fechaFin, Integer tiempoMinutos,
+            LocalDateTime fechaInicio, LocalDateTime fechaFin, Integer tiempoMinutos, Integer tiempoSegundos,
             Integer puntuacion, Integer nota, Integer numAbandonos,
             List<IntentoDetalleRespuestaDTO> respuestas) {
         this.intentoId = intentoId;
@@ -39,6 +40,7 @@ public class IntentoActividadDetalleDTO {
         this.fechaInicio = fechaInicio;
         this.fechaFin = fechaFin;
         this.tiempoMinutos = tiempoMinutos;
+        this.tiempoSegundos = tiempoSegundos;
         this.puntuacion = puntuacion;
         this.nota = nota;
         this.numAbandonos = numAbandonos;
@@ -131,6 +133,14 @@ public class IntentoActividadDetalleDTO {
 
     public void setTiempoMinutos(Integer tiempoMinutos) {
         this.tiempoMinutos = tiempoMinutos;
+    }
+
+    public Integer getTiempoSegundos() {
+        return tiempoSegundos;
+    }
+
+    public void setTiempoSegundos(Integer tiempoSegundos) {
+        this.tiempoSegundos = tiempoSegundos;
     }
 
     public Integer getPuntuacion() {

--- a/backend/src/main/java/com/cerebrus/estadisticas/dto/IntentoDetalleRespuestaDTO.java
+++ b/backend/src/main/java/com/cerebrus/estadisticas/dto/IntentoDetalleRespuestaDTO.java
@@ -7,16 +7,18 @@ public class IntentoDetalleRespuestaDTO {
     private String enunciado;
     private String respuestaAlumno;
     private Boolean correcta;
+    private Integer numFallos;
 
     public IntentoDetalleRespuestaDTO() {}
 
     public IntentoDetalleRespuestaDTO(Long respuestaId, String tipoRespuesta, String enunciado,
-            String respuestaAlumno, Boolean correcta) {
+            String respuestaAlumno, Boolean correcta, Integer numFallos) {
         this.respuestaId = respuestaId;
         this.tipoRespuesta = tipoRespuesta;
         this.enunciado = enunciado;
         this.respuestaAlumno = respuestaAlumno;
         this.correcta = correcta;
+        this.numFallos = numFallos;
     }
 
     public Long getRespuestaId() {
@@ -57,5 +59,13 @@ public class IntentoDetalleRespuestaDTO {
 
     public void setCorrecta(Boolean correcta) {
         this.correcta = correcta;
+    }
+
+    public Integer getNumFallos() {
+        return numFallos;
+    }
+
+    public void setNumFallos(Integer numFallos) {
+        this.numFallos = numFallos;
     }
 }

--- a/backend/src/main/java/com/cerebrus/respuestaAlumn/respAlumGeneral/RespAlumnoGeneral.java
+++ b/backend/src/main/java/com/cerebrus/respuestaAlumn/respAlumGeneral/RespAlumnoGeneral.java
@@ -16,6 +16,9 @@ public class RespAlumnoGeneral extends RespuestaAlumno {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String respuesta;
 
+    @Column(nullable = false)
+    private Integer numFallos = 0;
+
     //Relaciones
     @ManyToOne(fetch = jakarta.persistence.FetchType.LAZY)
     private Pregunta pregunta;
@@ -29,6 +32,7 @@ public class RespAlumnoGeneral extends RespuestaAlumno {
         super(correcta, actividadAlumno);
         this.respuesta = respuesta;
         this.pregunta = pregunta;
+        this.numFallos = 0;
     }
 
     // Getters y Setters
@@ -38,6 +42,14 @@ public class RespAlumnoGeneral extends RespuestaAlumno {
 
     public void setRespuesta(String respuesta) {
         this.respuesta = respuesta;
+    }
+
+    public Integer getNumFallos() {
+        return numFallos;
+    }
+
+    public void setNumFallos(Integer numFallos) {
+        this.numFallos = numFallos;
     }
 
     public Pregunta getPregunta() {
@@ -53,6 +65,7 @@ public class RespAlumnoGeneral extends RespuestaAlumno {
         return "RespAlumnoGeneral{" +
                 "id=" + getId() +
                 ", correcta=" + getCorrecta() +
+                ", numFallos=" + numFallos +
                 ", respuesta='" + respuesta + '\'' +
                 '}';
     }

--- a/backend/src/main/java/com/cerebrus/respuestaAlumn/respAlumGeneral/RespAlumnoGeneralServiceImpl.java
+++ b/backend/src/main/java/com/cerebrus/respuestaAlumn/respAlumGeneral/RespAlumnoGeneralServiceImpl.java
@@ -15,9 +15,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.cerebrus.actividad.ActividadRepository;
 import com.cerebrus.actividad.general.General;
-import com.cerebrus.comun.enumerados.TipoActGeneral;
 import com.cerebrus.actividadAlumn.ActividadAlumno;
 import com.cerebrus.actividadAlumn.ActividadAlumnoRepository;
+import com.cerebrus.comun.enumerados.TipoActGeneral;
 import com.cerebrus.exceptions.ResourceNotFoundException;
 import com.cerebrus.iaconnection.IaConnectionService;
 import com.cerebrus.pregunta.Pregunta;
@@ -205,7 +205,8 @@ public class RespAlumnoGeneralServiceImpl implements RespAlumnoGeneralService {
                     r.getPregunta() != null ? r.getPregunta().getId() : null,
                     r.getRespuesta(),
                     r.getCorrecta(),
-                    respuestaCorrecta);
+                    respuestaCorrecta,
+                    r.getNumFallos());
             })
             .toList();
     }

--- a/backend/src/main/java/com/cerebrus/respuestaAlumn/respAlumGeneral/dto/RespAlumnoGeneralResumenDTO.java
+++ b/backend/src/main/java/com/cerebrus/respuestaAlumn/respAlumGeneral/dto/RespAlumnoGeneralResumenDTO.java
@@ -6,15 +6,17 @@ public class RespAlumnoGeneralResumenDTO {
     private String respuesta;
     private Boolean correcta;
     private String respuestaCorrecta;
+    private Integer numFallos;
 
     public RespAlumnoGeneralResumenDTO() {
     }
 
-    public RespAlumnoGeneralResumenDTO(Long preguntaId, String respuesta, Boolean correcta, String respuestaCorrecta) {
+    public RespAlumnoGeneralResumenDTO(Long preguntaId, String respuesta, Boolean correcta, String respuestaCorrecta, Integer numFallos) {
         this.preguntaId = preguntaId;
         this.respuesta = respuesta;
         this.correcta = correcta;
         this.respuestaCorrecta = respuestaCorrecta;
+        this.numFallos = numFallos;
     }
 
     public Long getPreguntaId() {
@@ -47,5 +49,13 @@ public class RespAlumnoGeneralResumenDTO {
 
     public void setRespuestaCorrecta(String respuestaCorrecta) {
         this.respuestaCorrecta = respuestaCorrecta;
+    }
+
+    public Integer getNumFallos() {
+        return numFallos;
+    }
+
+    public void setNumFallos(Integer numFallos) {
+        this.numFallos = numFallos;
     }
 }

--- a/backend/src/main/resources/db/migration/V12__add_num_fallos_to_resp_alumno_general.sql
+++ b/backend/src/main/resources/db/migration/V12__add_num_fallos_to_resp_alumno_general.sql
@@ -1,0 +1,2 @@
+ALTER TABLE resp_alumno_general
+    ADD COLUMN IF NOT EXISTS num_fallos INTEGER NOT NULL DEFAULT 0;

--- a/backend/src/test/java/com/cerebrus/actividadAlumnTest/ActividadAlumnoServiceImplTest.java
+++ b/backend/src/test/java/com/cerebrus/actividadAlumnTest/ActividadAlumnoServiceImplTest.java
@@ -569,9 +569,39 @@ class ActividadAlumnoServiceImplTest {
 
         ActividadAlumno resultado = service.corregirActAlumnoAutomaticamente(10L, List.of(101L, 102L));
 
-        // 1 correcta: +50, 1 incorrecta: -25 → 25
-        assertThat(resultado.getPuntuacion()).isEqualTo(25);
-        assertThat(resultado.getNota()).isEqualTo(3); // round(2.5)
+        // 1 correcta de 2: 50 puntos y nota 5, sin penalización por fallo.
+        assertThat(resultado.getPuntuacion()).isEqualTo(50);
+        assertThat(resultado.getNota()).isEqualTo(5);
+    }
+
+    @Test
+    void corregirActAlumnoAutomaticamente_tipoTest_tresPreguntas_sinPenalizacion_reparte100Entre3() {
+        when(usuarioService.findCurrentUser()).thenReturn(alumno);
+        General actividadGeneral = crearActividadGeneral(TipoActGeneral.TEST, 100, 3);
+        actividadAlumno.setActividad(actividadGeneral);
+
+        Pregunta pregunta1 = actividadGeneral.getPreguntas().get(0);
+        Pregunta pregunta2 = actividadGeneral.getPreguntas().get(1);
+        Pregunta pregunta3 = actividadGeneral.getPreguntas().get(2);
+        pregunta1.setRespuestasMaestro(List.of(crearRespuestaMaestro("p1_ok", true), crearRespuestaMaestro("p1_bad", false)));
+        pregunta2.setRespuestasMaestro(List.of(crearRespuestaMaestro("p2_ok", true), crearRespuestaMaestro("p2_bad", false)));
+        pregunta3.setRespuestasMaestro(List.of(crearRespuestaMaestro("p3_ok", true), crearRespuestaMaestro("p3_bad", false)));
+
+        // Solo acierta 1 de 3 preguntas: 100/3 = 33.33 -> round = 33.
+        RespAlumnoGeneral resp1 = crearRespAlumnoGeneral(101L, pregunta1, "p1_ok");
+        RespAlumnoGeneral resp2 = crearRespAlumnoGeneral(102L, pregunta2, "p2_bad");
+        RespAlumnoGeneral resp3 = crearRespAlumnoGeneral(103L, pregunta3, "p3_bad");
+
+        when(actividadAlumnoRepository.findById(10L)).thenReturn(Optional.of(actividadAlumno));
+        when(respuestaAlumnoService.encontrarRespuestaAlumnoPorId(101L)).thenReturn(resp1);
+        when(respuestaAlumnoService.encontrarRespuestaAlumnoPorId(102L)).thenReturn(resp2);
+        when(respuestaAlumnoService.encontrarRespuestaAlumnoPorId(103L)).thenReturn(resp3);
+        when(actividadAlumnoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        ActividadAlumno resultado = service.corregirActAlumnoAutomaticamente(10L, List.of(101L, 102L, 103L));
+
+        assertThat(resultado.getPuntuacion()).isEqualTo(33);
+        assertThat(resultado.getNota()).isEqualTo(3);
     }
 
     @Test

--- a/backend/src/test/java/com/cerebrus/actividadAlumnTest/ActividadAlumnoServiceImplTest.java
+++ b/backend/src/test/java/com/cerebrus/actividadAlumnTest/ActividadAlumnoServiceImplTest.java
@@ -29,6 +29,7 @@ import com.cerebrus.actividad.marcarImagen.MarcarImagen;
 import com.cerebrus.actividad.marcarImagen.MarcarImagenService;
 import com.cerebrus.actividad.ordenacion.Ordenacion;
 import com.cerebrus.actividad.ordenacion.OrdenacionService;
+import com.cerebrus.actividad.tablero.Tablero;
 import com.cerebrus.actividadAlumn.ActividadAlumno;
 import com.cerebrus.actividadAlumn.ActividadAlumnoRepository;
 import com.cerebrus.actividadAlumn.ActividadAlumnoServiceImpl;
@@ -612,6 +613,32 @@ class ActividadAlumnoServiceImplTest {
 
         assertThat(resultado.getNota()).isEqualTo(10);
         assertThat(resultado.getPuntuacion()).isEqualTo(100);
+    }
+
+    @Test
+    void corregirActAlumnoAutomaticamente_tipoTablero_penalizaFallosAcumulados() {
+        when(usuarioService.findCurrentUser()).thenReturn(alumno);
+
+        Tablero tablero = new Tablero();
+        tablero.setId(60L);
+        tablero.setPuntuacion(100);
+        tablero.setPreguntas(new ArrayList<>());
+        actividadAlumno.setActividad(tablero);
+
+        RespAlumnoGeneral resp1 = new RespAlumnoGeneral(false, actividadAlumno, "fallo", new Pregunta());
+        resp1.setNumFallos(2);
+        RespAlumnoGeneral resp2 = new RespAlumnoGeneral(true, actividadAlumno, "bien", new Pregunta());
+        resp2.setNumFallos(0);
+        actividadAlumno.setRespuestasAlumno(new ArrayList<>(List.of(resp1, resp2)));
+
+        when(actividadAlumnoRepository.findById(10L)).thenReturn(Optional.of(actividadAlumno));
+        when(actividadAlumnoRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        ActividadAlumno resultado = service.corregirActAlumnoAutomaticamente(10L, List.of());
+
+        assertThat(resultado.getNota()).isEqualTo(8);
+        assertThat(resultado.getPuntuacion()).isEqualTo(80);
+        assertThat(resultado.getFechaFin()).isNotNull();
     }
 
     @Test

--- a/backend/src/test/java/com/cerebrus/estadisticas/EstadisticasMaestroControllerTest.java
+++ b/backend/src/test/java/com/cerebrus/estadisticas/EstadisticasMaestroControllerTest.java
@@ -1,18 +1,17 @@
 package com.cerebrus.estadisticas;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -271,7 +270,7 @@ class EstadisticasMaestroControllerTest {
     @Test
     void obtenerResumenEstadisticasAlumno_alumnoExistente_retorna200ConResumen() {
         EstadisticasAlumnoResumenDTO resumen = new EstadisticasAlumnoResumenDTO(
-                2L, "Alumno 1", 8.5, 6, 10, 3, 5, 120, List.of());
+                2L, "Alumno 1", 8.5, 6, 10, 3, 5, 120, 0, List.of());
         when(estadisticasMaestroService.obtenerResumenEstadisticasAlumno(10L, 2L)).thenReturn(resumen);
 
         ResponseEntity<?> respuesta = controller.obtenerResumenEstadisticasAlumno(10L, 2L);

--- a/backend/src/test/java/com/cerebrus/estadisticas/dto/EstadisticasDTOTest.java
+++ b/backend/src/test/java/com/cerebrus/estadisticas/dto/EstadisticasDTOTest.java
@@ -1,11 +1,10 @@
 package com.cerebrus.estadisticas.dto;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 class EstadisticasDTOTest {
@@ -79,7 +78,7 @@ class EstadisticasDTOTest {
         LocalDateTime fin = LocalDateTime.now();
         
         IntentoActividadDTO dto = new IntentoActividadDTO(
-            1L, inicio, fin, 100, 9, 30, 0);
+            1L, inicio, fin, 100, 9, 30, 0, 0);
 
         assertThat(dto.getId()).isEqualTo(1L);
         assertThat(dto.getFechaInicio()).isEqualTo(inicio);
@@ -431,7 +430,7 @@ class EstadisticasDTOTest {
         List<TemaEstadisticasAlumnoDTO> temas = new ArrayList<>();
         
         EstadisticasAlumnoResumenDTO dto = new EstadisticasAlumnoResumenDTO(
-            1L, "Juan Pérez", 7.5, 6, 9, 5, 8, 120, temas);
+            1L, "Juan Pérez", 7.5, 6, 9, 5, 8, 120, 0, temas);
 
         assertThat(dto.getAlumnoId()).isEqualTo(1L);
         assertThat(dto.getNombreAlumno()).isEqualTo("Juan Pérez");
@@ -488,7 +487,7 @@ class EstadisticasDTOTest {
     @Test
     void intentoActividadDTO_withNullDates_handlesCorrectly() {
         IntentoActividadDTO dto = new IntentoActividadDTO(
-            1L, null, null, 100, 9, 30, 0);
+            1L, null, null, 100, 9, 30, 0, 0);
 
         assertThat(dto.getId()).isEqualTo(1L);
         assertThat(dto.getFechaInicio()).isNull();

--- a/backend/src/test/java/com/cerebrus/tableroTest/TableroServiceImplTest.java
+++ b/backend/src/test/java/com/cerebrus/tableroTest/TableroServiceImplTest.java
@@ -1,20 +1,27 @@
 package com.cerebrus.tableroTest;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.access.AccessDeniedException;
 
@@ -554,6 +561,34 @@ public class TableroServiceImplTest {
 		assertThat(result).isEqualTo("Respuesta correcta");
 		String result2 = tableroService.crearRespuestaAPreguntaEnActTablero("incorrecta", 1L, 2L);
 		assertThat(result2).isEqualTo("Respuesta incorrecta");
+	}
+
+	@Test
+	void crearRespuestaAPreguntaTablero_penalizaCadaIntentoIncorrecto() {
+		Alumno alumno = mock(Alumno.class);
+		Pregunta pregunta = buildPreguntaWithRespuestaMaestro(2L, "respuesta");
+		Tablero tablero = buildTableroWithAlumno(alumno, pregunta, true, true, true, 100, true);
+		lenient().when(tableroRepository.findById(1L)).thenReturn(Optional.of(tablero));
+		lenient().when(preguntaRepository.findById(2L)).thenReturn(Optional.of(pregunta));
+		lenient().when(usuarioService.findCurrentUser()).thenReturn(alumno);
+		lenient().when(pregunta.getActividad()).thenReturn(tablero);
+
+		ActividadAlumno actividadAlumno = mock(ActividadAlumno.class);
+		lenient().when(actividadAlumno.getId()).thenReturn(11L);
+		List<RespuestaAlumno> respuestasAlumno = new ArrayList<>();
+		lenient().when(actividadAlumno.getRespuestasAlumno()).thenReturn(respuestasAlumno);
+		lenient().when(actividadAlumnoService.crearActAlumno(anyInt(), any(), any(), anyInt(), anyInt(), anyLong(), anyLong())).thenReturn(actividadAlumno);
+
+		String result1 = tableroService.crearRespuestaAPreguntaEnActTablero("fallo1", 1L, 2L);
+		String result2 = tableroService.crearRespuestaAPreguntaEnActTablero("fallo2", 1L, 2L);
+		String result3 = tableroService.crearRespuestaAPreguntaEnActTablero("respuesta", 1L, 2L);
+
+		assertThat(result1).contains("Respuesta incorrecta");
+		assertThat(result2).contains("Respuesta incorrecta");
+		assertThat(result3).contains("Respuesta correcta");
+		assertThat(respuestasAlumno).hasSize(1);
+		verify(actividadAlumno).setNota(8);
+		verify(actividadAlumno).setPuntuacion(80);
 	}
 
     	// Helper to build a Tablero with all required mocks for alumno scenario

--- a/frontend/src/components/ActivityResultScreen/ActivityResultScreen.css
+++ b/frontend/src/components/ActivityResultScreen/ActivityResultScreen.css
@@ -85,6 +85,13 @@
   text-shadow: none;
 }
 
+.ars-score-detail {
+  margin-top: 8px;
+  font-size: 0.95rem;
+  color: #4f4330;
+  line-height: 1.35;
+}
+
 .ars-imgs {
   display: flex;
   justify-content: center;

--- a/frontend/src/components/ActivityResultScreen/ActivityResultScreen.tsx
+++ b/frontend/src/components/ActivityResultScreen/ActivityResultScreen.tsx
@@ -14,6 +14,7 @@ interface Props {
   readonly score?: number;
   readonly maxScore?: number;
   readonly grade?: number;
+  readonly detail?: string;
   readonly config: ActivityResultConfig;
   readonly onContinue: () => void;
   readonly onRetry?: () => void;
@@ -27,6 +28,7 @@ export default function ActivityResultScreen({
   score = 0,
   maxScore = 100,
   grade,
+  detail,
   config,
   onContinue,
   onRetry,
@@ -59,6 +61,7 @@ export default function ActivityResultScreen({
               <span className="ars-score-max">/ {maxScore}</span>
             </div>
             <div className="ars-score-grade">Nota: {notaSobre10.toFixed(1)} / 10</div>
+            {detail && <div className="ars-score-detail">{detail}</div>}
           </div>
         )}
 

--- a/frontend/src/pages/estadisticasCurso/DetalleIntentoActividad.css
+++ b/frontend/src/pages/estadisticasCurso/DetalleIntentoActividad.css
@@ -181,6 +181,13 @@
   word-break: break-word;
 }
 
+.dia-respuesta-fallos {
+  margin-top: 8px !important;
+  color: #7a5d1f !important;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
 .dia-empty {
   color: #7d6b4d;
   font-style: italic;

--- a/frontend/src/pages/estadisticasCurso/DetalleIntentoActividad.tsx
+++ b/frontend/src/pages/estadisticasCurso/DetalleIntentoActividad.tsx
@@ -46,7 +46,10 @@ function formatFecha(iso?: string | null): string {
 }
 
 function formatTiempo(min?: number | null, segundos?: number | null): string {
-  const totalSegundos = ((min ?? 0) * 60) + (segundos ?? 0);
+  const totalSegundos =
+    typeof segundos === 'number' && Number.isFinite(segundos)
+      ? segundos
+      : (min ?? 0) * 60;
   if (totalSegundos <= 0) return '—';
   if (totalSegundos < 60) return `${totalSegundos} s`;
   const mins = Math.floor(totalSegundos / 60);

--- a/frontend/src/pages/estadisticasCurso/DetalleIntentoActividad.tsx
+++ b/frontend/src/pages/estadisticasCurso/DetalleIntentoActividad.tsx
@@ -10,6 +10,7 @@ interface RespuestaIntento {
   enunciado: string;
   respuestaAlumno: string;
   correcta: boolean | null;
+  numFallos?: number | null;
 }
 
 interface IntentoDetalle {
@@ -78,6 +79,11 @@ export default function DetalleIntentoActividad() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+
+  const totalFallos = useMemo(
+    () => detalle?.respuestas.reduce((acc, respuesta) => acc + Number(respuesta.numFallos ?? 0), 0) ?? 0,
+    [detalle],
+  );
 
   useEffect(() => {
     if (!cursoId || !alumnoId || !actividadId || !intentoId) return;
@@ -185,6 +191,12 @@ export default function DetalleIntentoActividad() {
           <div className="dia-metric"><span>Tiempo</span><strong>{formatTiempo(detalle.tiempoMinutos)}</strong></div>
           <div className="dia-metric"><span>Abandonos</span><strong>{detalle.numAbandonos ?? 0}</strong></div>
           <div className="dia-metric"><span>Nota</span><strong>{detalle.nota ?? 0}/10</strong></div>
+          {detalle.actividadTipo === 'Tablero' && (
+            <div className="dia-metric">
+              <span>Fallos acumulados</span>
+              <strong>{totalFallos}</strong>
+            </div>
+          )}
         </div>
 
         <div className="dia-score-editor">
@@ -224,6 +236,11 @@ export default function DetalleIntentoActividad() {
                 </header>
                 <h3>{r.enunciado || `Respuesta #${idx + 1}`}</h3>
                 <p>{r.respuestaAlumno || 'Sin contenido'}</p>
+                {detalle.actividadTipo === 'Tablero' && typeof r.numFallos === 'number' && (
+                  <p className="dia-respuesta-fallos">
+                    Fallos previos en esta pregunta: {r.numFallos}
+                  </p>
+                )}
               </article>
             ))
           )}

--- a/frontend/src/pages/estadisticasCurso/DetalleIntentoActividad.tsx
+++ b/frontend/src/pages/estadisticasCurso/DetalleIntentoActividad.tsx
@@ -25,6 +25,7 @@ interface IntentoDetalle {
   fechaInicio: string;
   fechaFin: string;
   tiempoMinutos: number;
+  tiempoSegundos?: number;
   puntuacion: number;
   nota: number;
   numAbandonos: number;
@@ -44,9 +45,14 @@ function formatFecha(iso?: string | null): string {
   return `${d.toLocaleDateString('es-ES')} ${d.toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' })}`;
 }
 
-function formatTiempo(min?: number | null): string {
-  if (!min || min <= 0) return '—';
-  return `${min} min`;
+function formatTiempo(min?: number | null, segundos?: number | null): string {
+  const totalSegundos = ((min ?? 0) * 60) + (segundos ?? 0);
+  if (totalSegundos <= 0) return '—';
+  if (totalSegundos < 60) return `${totalSegundos} s`;
+  const mins = Math.floor(totalSegundos / 60);
+  const secs = totalSegundos % 60;
+  if (secs === 0) return mins === 1 ? '1 min' : `${mins} min`;
+  return `${mins} min ${secs} s`;
 }
 
 function tipoLegible(tipo: string): string {
@@ -188,7 +194,7 @@ export default function DetalleIntentoActividad() {
         <div className="dia-metrics">
           <div className="dia-metric"><span>Fecha inicio</span><strong>{formatFecha(detalle.fechaInicio)}</strong></div>
           <div className="dia-metric"><span>Fecha fin</span><strong>{formatFecha(detalle.fechaFin)}</strong></div>
-          <div className="dia-metric"><span>Tiempo</span><strong>{formatTiempo(detalle.tiempoMinutos)}</strong></div>
+          <div className="dia-metric"><span>Tiempo</span><strong>{formatTiempo(detalle.tiempoMinutos, detalle.tiempoSegundos)}</strong></div>
           <div className="dia-metric"><span>Abandonos</span><strong>{detalle.numAbandonos ?? 0}</strong></div>
           <div className="dia-metric"><span>Nota</span><strong>{detalle.nota ?? 0}/10</strong></div>
           {detalle.actividadTipo === 'Tablero' && (

--- a/frontend/src/pages/estadisticasCurso/EstadisticasAlumno.tsx
+++ b/frontend/src/pages/estadisticasCurso/EstadisticasAlumno.tsx
@@ -12,6 +12,7 @@ interface IntentoActividad {
   puntuacion: number;
   nota: number;
   tiempoMinutos: number;
+  tiempoSegundos?: number;
   numAbandonos: number;
 }
 
@@ -44,6 +45,7 @@ interface EstadisticasAlumnoData {
   numActividadesCompletadas: number;
   totalActividades: number;
   tiempoTotalMinutos: number;
+  tiempoTotalSegundos?: number;
   temas: TemaEstadisticas[];
 }
 
@@ -76,10 +78,14 @@ function formatFecha(iso: string | null): string {
   );
 }
 
-function formatTiempo(min: number): string {
-  if (!min || min <= 0) return '—';
-  if (min === 1) return '1 min';
-  return `${min} min`;
+function formatTiempo(min?: number | null, segundos?: number | null): string {
+  const totalSegundos = ((min ?? 0) * 60) + (segundos ?? 0);
+  if (totalSegundos <= 0) return '—';
+  if (totalSegundos < 60) return `${totalSegundos} s`;
+  const mins = Math.floor(totalSegundos / 60);
+  const secs = totalSegundos % 60;
+  if (secs === 0) return mins === 1 ? '1 min' : `${mins} min`;
+  return `${mins} min ${secs} s`;
 }
 
 function notaBadgeClass(nota: number | null, media: number): string {
@@ -167,7 +173,7 @@ export default function EstadisticasAlumno({ cursoIdProp, alumnoId }: Estadistic
       { label: 'Nota mínima', value: data.notaMin !== null ? String(data.notaMin) : '—', mod: 'min' },
       { label: 'Nota máxima', value: data.notaMax !== null ? String(data.notaMax) : '—', mod: 'max' },
       { label: 'Actividades', value: `${data.numActividadesCompletadas}/${data.totalActividades}`, mod: 'completadas' },
-      { label: 'Tiempo total', value: formatTiempo(data.tiempoTotalMinutos), mod: 'tiempo' },
+      { label: 'Tiempo total', value: formatTiempo(data.tiempoTotalMinutos, data.tiempoTotalSegundos), mod: 'tiempo' },
     ];
   }, [data]);
 
@@ -275,7 +281,7 @@ export default function EstadisticasAlumno({ cursoIdProp, alumnoId }: Estadistic
                                 {intento.puntuacion !== null ? `${intento.puntuacion} pts` : '—'}
                               </span>
                               <span className="ea-intento-tiempo">
-                                {formatTiempo(intento.tiempoMinutos)}
+                                {formatTiempo(intento.tiempoMinutos, intento.tiempoSegundos)}
                               </span>
                               {intento.numAbandonos > 0 && (
                                 <span className="ea-intento-abandonos">

--- a/frontend/src/pages/estadisticasCurso/EstadisticasAlumno.tsx
+++ b/frontend/src/pages/estadisticasCurso/EstadisticasAlumno.tsx
@@ -79,7 +79,10 @@ function formatFecha(iso: string | null): string {
 }
 
 function formatTiempo(min?: number | null, segundos?: number | null): string {
-  const totalSegundos = ((min ?? 0) * 60) + (segundos ?? 0);
+  const totalSegundos =
+    typeof segundos === 'number' && Number.isFinite(segundos)
+      ? segundos
+      : (min ?? 0) * 60;
   if (totalSegundos <= 0) return '—';
   if (totalSegundos < 60) return `${totalSegundos} s`;
   const mins = Math.floor(totalSegundos / 60);

--- a/frontend/src/pages/tableroAlumno/TableroAlumno.tsx
+++ b/frontend/src/pages/tableroAlumno/TableroAlumno.tsx
@@ -44,6 +44,7 @@ type RespAlumnoGeneralResumenDTO = {
   readonly respuesta: string;
   readonly correcta?: boolean | null;
   readonly respuestaCorrecta?: string | null;
+  readonly numFallos?: number | null;
 };
 
 // ── Helpers ───────────────────────────────────────────────
@@ -258,12 +259,14 @@ export default function TableroAlumno() {
   const [answerHistory, setAnswerHistory] = useState<Map<number, string>>(new Map());
   const [submittedAnswersByQuestion, setSubmittedAnswersByQuestion] = useState<Map<number, string>>(new Map());
   const [correctAnswersByQuestion, setCorrectAnswersByQuestion] = useState<Map<number, string>>(new Map());
+  const [boardFailureCount, setBoardFailureCount] = useState(0);
 
   const hydrateAnswersFromHistory = useCallback(async (actividadAlumnoIdValue: number) => {
     const histRes = await apiFetch(`${API_BASE}/api/respuestas-alumno-general/actividad-alumno/${actividadAlumnoIdValue}`);
     const histData = (await histRes.json()) as RespAlumnoGeneralResumenDTO[];
     const studentMap = new Map<number, string>();
     const correctMap = new Map<number, string>();
+    let failureCount = 0;
 
     for (const item of histData) {
       if (typeof item.preguntaId !== 'number') continue;
@@ -271,10 +274,12 @@ export default function TableroAlumno() {
       if (item.respuestaCorrecta && !correctMap.has(item.preguntaId)) {
         correctMap.set(item.preguntaId, item.respuestaCorrecta);
       }
+      failureCount += Number(item.numFallos ?? 0);
     }
 
     setSubmittedAnswersByQuestion(studentMap);
     setCorrectAnswersByQuestion(correctMap);
+    setBoardFailureCount(failureCount);
   }, []);
 
   // Sincronizar el ID para el cleanup del abandono
@@ -344,6 +349,7 @@ export default function TableroAlumno() {
                 } catch {
                   setSubmittedAnswersByQuestion(new Map());
                   setCorrectAnswersByQuestion(new Map());
+                  setBoardFailureCount(0);
                 }
               }
             }
@@ -470,6 +476,7 @@ export default function TableroAlumno() {
   const modalQuestion = modalQIdx !== null ? tablero.preguntas[modalQIdx] : null;
 
   const handleRetry = () => {
+    setLastAttemptScore(null);
     setCerberoPos([0, 0]);
     setAnsweredSet(new Set());
     setModalCell(null);
@@ -479,6 +486,7 @@ export default function TableroAlumno() {
     setAnswerHistory(new Map());
     setSubmittedAnswersByQuestion(new Map());
     setCorrectAnswersByQuestion(new Map());
+    setBoardFailureCount(0);
     completedRef.current = false;
   };
 
@@ -526,17 +534,22 @@ export default function TableroAlumno() {
           )}
 
           {showCompleted && activityConfig ? (
-            <ActivityResultScreen
-              title="¡HAS COMPLETADO EL TABLERO!"
-              score={lastAttemptScore ?? answeredSet.size}
-              maxScore={tablero.puntuacion ?? completionTarget}
-              config={activityConfig}
-              onContinue={() => navigate(-1)}
-              onRetry={handleRetry}
-              onViewStudentAnswer={handleViewStudentAnswers}
-              onViewCorrectAnswer={handleViewCorrectAnswers}
-              onCancel={() => navigate(-1)}
-            />
+            <>
+              <ActivityResultScreen
+                title="¡HAS COMPLETADO EL TABLERO!"
+                score={lastAttemptScore ?? answeredSet.size}
+                maxScore={tablero.puntuacion ?? completionTarget}
+                config={activityConfig}
+                onContinue={() => navigate(-1)}
+                onRetry={handleRetry}
+                onViewStudentAnswer={handleViewStudentAnswers}
+                onViewCorrectAnswer={handleViewCorrectAnswers}
+                onCancel={() => navigate(-1)}
+                detail={boardFailureCount > 0
+                  ? `Penalización acumulada: ${boardFailureCount} fallo${boardFailureCount === 1 ? '' : 's'} antes de acertar.`
+                  : 'Sin penalización por fallos.'}
+              />
+            </>
           ) : showCompleted ? (
             <CompletionPopup title="¡HAS COMPLETADO EL TABLERO!" onContinue={() => navigate(-1)} />
           ) : null}


### PR DESCRIPTION
Cosas resueltas:
Cuando un alumno contesta una actividad de tablero con el check de Ver correcciones activo por parte del profesor, el alumno puede ver la respuesta correcta al fallar pero no cuenta como un fallo o intento, por lo que en las estadisticas le sale al profesor que esta bien la actividad entera. Se podría añadir que penalice por fallo para que sea realista.

Por otra parte, cuando una actividad tarda menos de 1 min en completarse, aparece un - en las estadísticas. Se podría cambiar para que guarde también los segundos o si es menos de un minuto especificarlo poniendo "menos de 1 min" en las estadísticas.

He hecho una actividad tipo test y he respondido bien 1 de 3 pero tanto la puntuación como la nota sobre 10 han sido 0.