### PR TITLE
fix: :bug: arreglada edición de curso

### DIFF
--- a/backend/src/main/java/com/cerebrus/curso/CursoController.java
+++ b/backend/src/main/java/com/cerebrus/curso/CursoController.java
@@ -94,7 +94,7 @@ public class CursoController {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
             } else if (e.getMessage().equals("403 Forbidden")) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-            } else if (e.getMessage().equals("Este código ya esta en uso, por favor elige otro")) {
+            } else if (e.getMessage().equals("Este código ya es utilizado por otro curso, por favor elige otro")) {
                 return ResponseEntity.status(HttpStatus.CONFLICT).build();
             }else {
                 return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();

--- a/backend/src/main/java/com/cerebrus/curso/CursoServiceImpl.java
+++ b/backend/src/main/java/com/cerebrus/curso/CursoServiceImpl.java
@@ -44,6 +44,15 @@ public class CursoServiceImpl implements CursoService {
             throw new RuntimeException("Este código ya esta en uso, por favor elige otro");
         }
     }
+    public void validarCodigoUnicoActualizar(String codigo, Long id) {
+        // En la actualización, el código puede ser el mismo que el del curso que se está actualizando, 
+        // pero no puede ser el mismo que el de otro curso diferente.
+        Curso curso = cursoRepository.findByCodigo(codigo);
+        if (curso != null && !curso.getId().equals(id)) {
+            throw new RuntimeException("Este código ya es utilizado por otro curso, por favor elige otro");
+        }
+    }
+
     @Transactional
     @Override
     public Curso crearCurso(String titulo, String descripcion, String imagen, String codigoPersonalizado) {
@@ -137,7 +146,7 @@ public class CursoServiceImpl implements CursoService {
         if (!curso.getMaestro().getId().equals(usuario.getId())) {
             throw new AccessDeniedException("Solo el propietario del curso puede actualizarlo");
         }
-        validarCodigoUnico(codigo);
+        validarCodigoUnicoActualizar(codigo, id);
         curso.setTitulo(titulo);
         curso.setDescripcion(descripcion);
         curso.setImagen(imagen);


### PR DESCRIPTION
Ahora es posible editar un curso sin error de duplicidad de código de curso cuando dicho código no es modificado. Se ha creado una nueva función para el caso de actualizar que comprueba si existe un curso con ese código que sea distinto al curso que se está actualizando, así es posible modificar un curso cambiando cualquier propiedad sin tener que modificar el código de acceso.

Refs #386