### PR TITLE
arreglos en estadísticas

### DIFF
--- a/frontend/src/pages/estadisticasCurso/EstadisticasActividad.tsx
+++ b/frontend/src/pages/estadisticasCurso/EstadisticasActividad.tsx
@@ -66,7 +66,7 @@ export default function EstadisticasActividad({ actividadIdProp, cursoIdProp, em
       if (!statsRes.ok) throw new Error('Error al cargar las estadísticas de la actividad');
 
       const data = (await statsRes.json()) as RapidosLentosDTO;
-      const alumnosCursoData: AlumnoInscritoCursoDTO[] | null = alumnosCursoRes && alumnosCursoRes.ok
+      const alumnosCursoData: AlumnoInscritoCursoDTO[] | null = alumnosCursoRes?.ok
         ? await alumnosCursoRes.json()
         : null;
 

--- a/frontend/src/pages/estadisticasCurso/EstadisticasActividad.tsx
+++ b/frontend/src/pages/estadisticasCurso/EstadisticasActividad.tsx
@@ -15,6 +15,11 @@ interface RapidosLentosDTO {
   promedio: number;
 }
 
+interface AlumnoInscritoCursoDTO {
+  alumnoId: number;
+  nombre: string;
+}
+
 function formatearTiempo(minutos: number): string {
   if (minutos === 0) return '0 mins';
   if (!minutos || minutos < 0) return '< 1 min';
@@ -24,10 +29,11 @@ function formatearTiempo(minutos: number): string {
 
 interface EstadisticasActividadProps {
   readonly actividadIdProp?: string;
+  readonly cursoIdProp?: string;
   readonly embedded?: boolean;
 }
 
-export default function EstadisticasActividad({ actividadIdProp, embedded }: EstadisticasActividadProps = {}) {
+export default function EstadisticasActividad({ actividadIdProp, cursoIdProp, embedded }: EstadisticasActividadProps = {}) {
   const params = useParams<{ id: string }>();
   const id = actividadIdProp ?? params.id;
   const navigate = useNavigate();
@@ -36,8 +42,8 @@ export default function EstadisticasActividad({ actividadIdProp, embedded }: Est
   const [error, setError] = useState('');
 
   useEffect(() => {
-    cargarEstadisticas();
-  }, [id]);
+    void cargarEstadisticas();
+  }, [id, cursoIdProp]);
 
   const cargarEstadisticas = async () => {
     setLoading(true);
@@ -46,14 +52,34 @@ export default function EstadisticasActividad({ actividadIdProp, embedded }: Est
       const token = localStorage.getItem('token');
       const apiBase = (import.meta.env.VITE_API_URL ?? "").trim().replace(/\/$/, "");
 
-      const res = await fetch(`${apiBase}/api/estadisticas/actividades/${id}/alumnos-rapidos-lentos?limite=1000`, {
-        headers: { 'Authorization': `Bearer ${token}` },
-      });
+      const [statsRes, alumnosCursoRes] = await Promise.all([
+        fetch(`${apiBase}/api/estadisticas/actividades/${id}/alumnos-rapidos-lentos?limite=1000`, {
+          headers: { 'Authorization': `Bearer ${token}` },
+        }),
+        cursoIdProp
+          ? fetch(`${apiBase}/api/inscripciones/curso/${cursoIdProp}/alumnos`, {
+              headers: { 'Authorization': `Bearer ${token}` },
+            })
+          : Promise.resolve(null),
+      ]);
 
-      if (!res.ok) throw new Error('Error al cargar las estadísticas de la actividad');
+      if (!statsRes.ok) throw new Error('Error al cargar las estadísticas de la actividad');
 
-      const data = await res.json();
-      setDatos(data);
+      const data = (await statsRes.json()) as RapidosLentosDTO;
+      const alumnosCursoData: AlumnoInscritoCursoDTO[] | null = alumnosCursoRes && alumnosCursoRes.ok
+        ? await alumnosCursoRes.json()
+        : null;
+
+      if (alumnosCursoData && alumnosCursoData.length > 0) {
+        const ids = new Set(alumnosCursoData.map(a => a.alumnoId));
+        setDatos({
+          ...data,
+          masRapidos: (data.masRapidos ?? []).filter(a => ids.has(a.alumnoId)),
+          masLentos: (data.masLentos ?? []).filter(a => ids.has(a.alumnoId)),
+        });
+      } else {
+        setDatos(data);
+      }
     } catch (err) {
       setError((err as Error).message);
     } finally {

--- a/frontend/src/pages/estadisticasCurso/EstadisticasCurso.css
+++ b/frontend/src/pages/estadisticasCurso/EstadisticasCurso.css
@@ -575,7 +575,6 @@ button.stats-alert-card:hover {
   border: 1px solid var(--t-border);
   border-radius: 12px;
   padding: 10px 12px;
-  font-family: 'Pixelify Sans', sans-serif;
   font-size: 1.25rem;
   font-weight: 700;
   text-align: center;

--- a/frontend/src/pages/estadisticasCurso/EstadisticasCurso.tsx
+++ b/frontend/src/pages/estadisticasCurso/EstadisticasCurso.tsx
@@ -18,6 +18,11 @@ interface EstadisticaAlumno {
   tiempoTotal: number;
 }
 
+interface AlumnoInscritoCursoDTO {
+  alumnoId: number;
+  nombre: string;
+}
+
 interface OpcionItem {
   id: number;
   nombre: string;
@@ -371,11 +376,12 @@ export default function EstadisticasCurso({ cursoId, embedded }: EstadisticasCur
       const apiBase = (import.meta.env.VITE_API_URL ?? "").trim().replace(/\/$/, "");
 
       // Hacemos 3 llamadas: Puntos, Actividades y la lista completa de tiempos (con límite 1000 para que vengan todos)
-      const [puntosRes, actividadesRes, tiemposRes, cursoRes] = await Promise.all([
+      const [puntosRes, actividadesRes, tiemposRes, cursoRes, alumnosCursoRes] = await Promise.all([
         fetch(`${apiBase}/api/estadisticas/cursos/${id}/puntos`, { headers: { 'Authorization': `Bearer ${token}` } }),
         fetch(`${apiBase}/api/estadisticas/cursos/${id}/actividades-completadas`, { headers: { 'Authorization': `Bearer ${token}` } }),
         fetch(`${apiBase}/api/estadisticas/cursos/${id}/alumnos-rapidos-lentos?limite=1000`, { headers: { 'Authorization': `Bearer ${token}` } }),
         fetch(`${apiBase}/api/estadisticas/cursos/${id}/estadisiticas-curso`, { headers: { 'Authorization': `Bearer ${token}` } }),
+        fetch(`${apiBase}/api/inscripciones/curso/${id}/alumnos`, { headers: { 'Authorization': `Bearer ${token}` } }),
       ]);
 
       if (!puntosRes.ok || !actividadesRes.ok) throw new Error('Error al cargar datos principales');
@@ -384,8 +390,13 @@ export default function EstadisticasCurso({ cursoId, embedded }: EstadisticasCur
       const actividadesData = await actividadesRes.json();
       const tiemposData = tiemposRes.ok ? await tiemposRes.json() : null;
       const cursoData: EstadisticasCursoDTO | null = cursoRes.ok ? await cursoRes.json() : null;
+      const alumnosCursoData: AlumnoInscritoCursoDTO[] | null = alumnosCursoRes.ok ? await alumnosCursoRes.json() : null;
 
       const alumnosMap = new Map<string, EstadisticaAlumno>();
+
+      const normalizeNombre = (value: string): string => value.trim().toLowerCase();
+      const alumnosCursoIds = alumnosCursoData ? new Set(alumnosCursoData.map(a => a.alumnoId)) : null;
+      const alumnosCursoNombres = alumnosCursoData ? new Set(alumnosCursoData.map(a => normalizeNombre(a.nombre))) : null;
 
       // 1. Procesar puntos
       Object.entries(puntosData).forEach(([nombre, puntos]) => {
@@ -402,17 +413,30 @@ export default function EstadisticasCurso({ cursoId, embedded }: EstadisticasCur
 
       // 3. Procesar tiempos desde el endpoint de tu compañero
       if (tiemposData && tiemposData.masRapidos) {
-        tiemposData.masRapidos.forEach((t: any) => {
+        const tiemposList = [...(tiemposData.masRapidos ?? []), ...(tiemposData.masLentos ?? [])];
+        tiemposList.forEach((t: any) => {
+          if (!t || typeof t.nombreAlumno !== 'string') return;
           if (!alumnosMap.has(t.nombreAlumno)) {
             alumnosMap.set(t.nombreAlumno, { nombre: t.nombreAlumno, puntos: 0, actividadesRealizadas: 0, tiempoTotal: 0 });
           }
-          // El backend de tu compañero nos da el tiempo exacto en minutos
-          alumnosMap.get(t.nombreAlumno)!.tiempoTotal = t.tiempoMinutos || 0;
-          alumnosMap.get(t.nombreAlumno)!.idAlumno = t.alumnoId;
+          // El backend nos da el tiempo exacto en minutos (para algunos alumnos según el límite)
+          alumnosMap.get(t.nombreAlumno)!.tiempoTotal = typeof t.tiempoMinutos === 'number' ? t.tiempoMinutos : (t.tiempoMinutos || 0);
+          if (typeof t.alumnoId === 'number') alumnosMap.get(t.nombreAlumno)!.idAlumno = t.alumnoId;
         });
       }
 
-      setEstadisticas(Array.from(alumnosMap.values()));
+      let estadisticasFinales = Array.from(alumnosMap.values());
+
+      // Filtrar expulsados: si un alumno ya no está inscrito, no debe aparecer en estadísticas.
+      // Priorizamos el cruce por ID cuando existe; si no, caemos a nombre.
+      if (alumnosCursoIds && alumnosCursoNombres) {
+        estadisticasFinales = estadisticasFinales.filter(e => {
+          if (typeof e.idAlumno === 'number') return alumnosCursoIds.has(e.idAlumno);
+          return alumnosCursoNombres.has(normalizeNombre(e.nombre));
+        });
+      }
+
+      setEstadisticas(estadisticasFinales);
       console.log('[cargarEstadisticas] alumnosMap:', Array.from(alumnosMap.entries()));
       setEstadisticasCurso(cursoData);
 
@@ -784,10 +808,11 @@ export default function EstadisticasCurso({ cursoId, embedded }: EstadisticasCur
       }
     };
 
-    const getActividadSortValue = (act: OpcionItem, st?: ActividadStats): string | number => {
+    const getActividadSortValue = (act: { id: number; nombre?: string; titulo?: string }, st?: ActividadStats): string | number => {
+      const label = String(act.nombre ?? act.titulo ?? '');
       switch (analisisTablaOrden) {
         case 'elemento':
-          return String(act.nombre ?? '').toLocaleLowerCase('es');
+          return label.toLocaleLowerCase('es');
         case 'tipo':
           return 'actividad';
         case 'notaMedia':
@@ -801,7 +826,7 @@ export default function EstadisticasCurso({ cursoId, embedded }: EstadisticasCur
         case 'completado':
           return st?.actividadCompletadaPorTodos == null ? 2 : (st.actividadCompletadaPorTodos ? 1 : 0);
         default:
-          return String(act.nombre ?? '').toLocaleLowerCase('es');
+          return label.toLocaleLowerCase('es');
       }
     };
 
@@ -1911,7 +1936,7 @@ export default function EstadisticasCurso({ cursoId, embedded }: EstadisticasCur
             <section className="analisis-panel analisis-panel--full">
               <h3 className="analisis-panel-title">Tiempos de la actividad seleccionada</h3>
               {analisisActividadId ? (
-                <EstadisticasActividad actividadIdProp={String(analisisActividadId)} embedded />
+                <EstadisticasActividad actividadIdProp={String(analisisActividadId)} cursoIdProp={id} embedded />
               ) : (
                 <div className="stats-placeholder">Selecciona una actividad para ver tiempos.</div>
               )}
@@ -1947,7 +1972,7 @@ export default function EstadisticasCurso({ cursoId, embedded }: EstadisticasCur
         />;
       case "tiemposActividad":
         if ('actividadId' in statsView && statsView.actividadId) {
-          return <EstadisticasActividad actividadIdProp={String(statsView.actividadId)} embedded />;
+          return <EstadisticasActividad actividadIdProp={String(statsView.actividadId)} cursoIdProp={id} embedded />;
         }
         return <div className="stats-placeholder">Selecciona una actividad de la lista</div>;
       case "alumnos":

--- a/frontend/src/pages/estadisticasCurso/EstadisticasTema.tsx
+++ b/frontend/src/pages/estadisticasCurso/EstadisticasTema.tsx
@@ -44,60 +44,86 @@ export default function EstadisticasTema({ temaIdProp, cursoIdProp, embedded }: 
     void cargarEstadisticas();
   }, [id, cursoIdProp]);
 
+  type FetchHeaders = Record<string, string>;
+
+  async function fetchJson<T>(url: string, headers: FetchHeaders): Promise<T> {
+    const res = await fetch(url, { headers });
+    if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+    return (await res.json()) as T;
+  }
+
+  async function fetchOptionalJson<T>(url: string, headers: FetchHeaders): Promise<T | null> {
+    try {
+      const res = await fetch(url, { headers });
+      if (!res.ok) return null;
+      return (await res.json()) as T;
+    } catch {
+      return null;
+    }
+  }
+
+  function filtrarPorIds(data: RapidosLentosDTO, ids: Set<number> | null): RapidosLentosDTO {
+    if (!ids) return data;
+    return {
+      ...data,
+      masRapidos: (data.masRapidos ?? []).filter(a => ids.has(a.alumnoId)),
+      masLentos: (data.masLentos ?? []).filter(a => ids.has(a.alumnoId)),
+    };
+  }
+
+  async function resolverCursoIdTema(
+    apiBase: string,
+    temaId: string,
+    headers: FetchHeaders,
+    cursoIdProp?: string
+  ): Promise<string | undefined> {
+    if (cursoIdProp) return cursoIdProp;
+
+    // TemaDTO tiene cursoId
+    const tema = await fetchOptionalJson<{ cursoId?: number | string }>(
+      `${apiBase}/api/temas/${temaId}`,
+      headers
+    );
+
+    return tema?.cursoId != null ? String(tema.cursoId) : undefined;
+  }
+
+  async function cargarIdsInscritos(
+    apiBase: string,
+    cursoId: string | undefined,
+    headers: FetchHeaders
+  ): Promise<Set<number> | null> {
+    if (!cursoId) return null;
+
+    const alumnos = await fetchOptionalJson<AlumnoInscritoCursoDTO[]>(
+      `${apiBase}/api/inscripciones/curso/${cursoId}/alumnos`,
+      headers
+    );
+
+    if (!alumnos || alumnos.length === 0) return null;
+    return new Set(alumnos.map(a => a.alumnoId));
+  }
+
+  // dentro del componente:
   const cargarEstadisticas = async () => {
     setLoading(true);
     setError('');
+
     try {
       const token = localStorage.getItem('token');
-      const apiBase = (import.meta.env.VITE_API_URL ?? "").trim().replace(/\/$/, "");
+      const apiBase = (import.meta.env.VITE_API_URL ?? '').trim().replace(/\/$/, '');
+      const headers = { Authorization: `Bearer ${token}` };
 
-      let cursoIdEfectivo: string | undefined = cursoIdProp;
-      if (!cursoIdEfectivo) {
-        try {
-          const temaRes = await fetch(`${apiBase}/api/temas/${id}`, {
-            headers: { 'Authorization': `Bearer ${token}` },
-          });
-          if (temaRes.ok) {
-            const temaData = await temaRes.json();
-            if (temaData && (typeof temaData.cursoId === 'number' || typeof temaData.cursoId === 'string')) {
-              cursoIdEfectivo = String(temaData.cursoId);
-            }
-          }
-        } catch {
-          // Si falla, seguimos sin filtro (comportamiento actual)
-        }
-      }
+      const cursoIdEfectivo = await resolverCursoIdTema(apiBase, id!, headers, cursoIdProp);
 
-      const [statsRes, alumnosCursoRes] = await Promise.all([
-        fetch(`${apiBase}/api/estadisticas/temas/${id}/alumnos-rapidos-lentos?limite=1000`, {
-          headers: { 'Authorization': `Bearer ${token}` },
-        }),
-        cursoIdEfectivo
-          ? fetch(`${apiBase}/api/inscripciones/curso/${cursoIdEfectivo}/alumnos`, {
-              headers: { 'Authorization': `Bearer ${token}` },
-            })
-          : Promise.resolve(null),
+      const [stats, idsInscritos] = await Promise.all([
+        fetchJson<RapidosLentosDTO>(`${apiBase}/api/estadisticas/temas/${id}/alumnos-rapidos-lentos?limite=1000`, headers),
+        cargarIdsInscritos(apiBase, cursoIdEfectivo, headers),
       ]);
 
-      if (!statsRes.ok) throw new Error('Error al cargar las estadísticas');
-
-      const data = (await statsRes.json()) as RapidosLentosDTO;
-      const alumnosCursoData: AlumnoInscritoCursoDTO[] | null = alumnosCursoRes && alumnosCursoRes.ok
-        ? await alumnosCursoRes.json()
-        : null;
-
-      if (alumnosCursoData && alumnosCursoData.length > 0) {
-        const ids = new Set(alumnosCursoData.map(a => a.alumnoId));
-        setDatos({
-          ...data,
-          masRapidos: (data.masRapidos ?? []).filter(a => ids.has(a.alumnoId)),
-          masLentos: (data.masLentos ?? []).filter(a => ids.has(a.alumnoId)),
-        });
-      } else {
-        setDatos(data);
-      }
+      setDatos(filtrarPorIds(stats, idsInscritos));
     } catch (err) {
-      setError((err as Error).message);
+      setError(err instanceof Error ? err.message : 'Error desconocido');
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/estadisticasCurso/EstadisticasTema.tsx
+++ b/frontend/src/pages/estadisticasCurso/EstadisticasTema.tsx
@@ -15,6 +15,11 @@ interface RapidosLentosDTO {
   promedio: number;
 }
 
+interface AlumnoInscritoCursoDTO {
+  alumnoId: number;
+  nombre: string;
+}
+
 function formatearTiempo(minutos: number): string {
   if (!minutos || minutos <= 0) return '0 mins';
   if (minutos === 1) return '1 min';
@@ -23,10 +28,11 @@ function formatearTiempo(minutos: number): string {
 
 interface EstadisticasTemaProps {
   readonly temaIdProp?: string;
+  readonly cursoIdProp?: string;
   readonly embedded?: boolean;
 }
 
-export default function EstadisticasTema({ temaIdProp, embedded }: EstadisticasTemaProps = {}) {
+export default function EstadisticasTema({ temaIdProp, cursoIdProp, embedded }: EstadisticasTemaProps = {}) {
   const params = useParams<{ id: string }>();
   const id = temaIdProp ?? params.id;
   const navigate = useNavigate();
@@ -35,8 +41,8 @@ export default function EstadisticasTema({ temaIdProp, embedded }: EstadisticasT
   const [error, setError] = useState('');
 
   useEffect(() => {
-    cargarEstadisticas();
-  }, [id]);
+    void cargarEstadisticas();
+  }, [id, cursoIdProp]);
 
   const cargarEstadisticas = async () => {
     setLoading(true);
@@ -44,15 +50,52 @@ export default function EstadisticasTema({ temaIdProp, embedded }: EstadisticasT
     try {
       const token = localStorage.getItem('token');
       const apiBase = (import.meta.env.VITE_API_URL ?? "").trim().replace(/\/$/, "");
-      
-      const res = await fetch(`${apiBase}/api/estadisticas/temas/${id}/alumnos-rapidos-lentos?limite=1000`, {
-        headers: { 'Authorization': `Bearer ${token}` },
-      });
 
-      if (!res.ok) throw new Error('Error al cargar las estadísticas');
+      let cursoIdEfectivo: string | undefined = cursoIdProp;
+      if (!cursoIdEfectivo) {
+        try {
+          const temaRes = await fetch(`${apiBase}/api/temas/${id}`, {
+            headers: { 'Authorization': `Bearer ${token}` },
+          });
+          if (temaRes.ok) {
+            const temaData = await temaRes.json();
+            if (temaData && (typeof temaData.cursoId === 'number' || typeof temaData.cursoId === 'string')) {
+              cursoIdEfectivo = String(temaData.cursoId);
+            }
+          }
+        } catch {
+          // Si falla, seguimos sin filtro (comportamiento actual)
+        }
+      }
 
-      const data = await res.json();
-      setDatos(data);
+      const [statsRes, alumnosCursoRes] = await Promise.all([
+        fetch(`${apiBase}/api/estadisticas/temas/${id}/alumnos-rapidos-lentos?limite=1000`, {
+          headers: { 'Authorization': `Bearer ${token}` },
+        }),
+        cursoIdEfectivo
+          ? fetch(`${apiBase}/api/inscripciones/curso/${cursoIdEfectivo}/alumnos`, {
+              headers: { 'Authorization': `Bearer ${token}` },
+            })
+          : Promise.resolve(null),
+      ]);
+
+      if (!statsRes.ok) throw new Error('Error al cargar las estadísticas');
+
+      const data = (await statsRes.json()) as RapidosLentosDTO;
+      const alumnosCursoData: AlumnoInscritoCursoDTO[] | null = alumnosCursoRes && alumnosCursoRes.ok
+        ? await alumnosCursoRes.json()
+        : null;
+
+      if (alumnosCursoData && alumnosCursoData.length > 0) {
+        const ids = new Set(alumnosCursoData.map(a => a.alumnoId));
+        setDatos({
+          ...data,
+          masRapidos: (data.masRapidos ?? []).filter(a => ids.has(a.alumnoId)),
+          masLentos: (data.masLentos ?? []).filter(a => ids.has(a.alumnoId)),
+        });
+      } else {
+        setDatos(data);
+      }
     } catch (err) {
       setError((err as Error).message);
     } finally {

--- a/frontend/src/pages/gestionAlumnos/GestionAlumnos.tsx
+++ b/frontend/src/pages/gestionAlumnos/GestionAlumnos.tsx
@@ -159,7 +159,7 @@ export default function GestionAlumnos({ cursoId, embedded }: Props) {
               <strong>
                 {confirmAlumno.nombre} {confirmAlumno.primerApellido}
               </strong>{" "}
-              de este curso? Esta acción no se puede deshacer.
+              de este curso? Sus estadísticas quedarán guardadas aunque no se te mostrarán. Puedes volver a inscribirlo en cualquier momento, recuperando sus estadísticas.
             </p>
             <div className="ga-modal-actions">
               <button


### PR DESCRIPTION
Las estadísticas tenían en cuenta a los alumnos expulsados porque se recopilaban todas las estadísticas relacionadas con el curso, incluyendo las de los alumnos que ya no estaban inscritos. Se ha cambiado para que se tenga en cuenta sólo a los alumnos inscritos, aunque las estadísticas se siguen guardando en la base de datos y al expulsar a un alumno de un curso sus estadísticas no se borran (de hecho, esto mismo se le indica al profesor en el mensaje de confirmación de expulsión de un alumno). Los cambios han afectado sólo al frontend.