### PR TITLE
arreglado el comportamiento de ver solución

### DIFF
--- a/frontend/src/pages/crearActividad/CrucigramaForm.tsx
+++ b/frontend/src/pages/crearActividad/CrucigramaForm.tsx
@@ -338,7 +338,7 @@ export function CrucigramaForm({ mode = 'create', crucigramaId, initialValues, t
                                     checked={encontrarRespuestaMaestro}
                                     onChange={e => {setEncontrarRespuestaMaestro(e.target.checked);}}
                                 />
-                                <span className="cf-checkbox-label">Mostrar respuesta correcta</span>
+                                <span className="cf-checkbox-label">Mostrar respuesta correcta después de finalizar</span>
                             </label>
                         </div>
                     </div>

--- a/frontend/src/pages/crucigramaAlumno/CrucigramaAlumno.tsx
+++ b/frontend/src/pages/crucigramaAlumno/CrucigramaAlumno.tsx
@@ -257,7 +257,7 @@ export default function CrucigramaAlumno() {
         setActivityConfig({
           showScore: data.mostrarPuntuacion ?? true,
           allowRetry: data.permitirReintento ?? false,
-          showCorrectAnswer: data.encontrarRespuestaMaestro ?? true,
+          showCorrectAnswer: data.respVisible,
           showStudentAnswer: data.encontrarRespuestaAlumno ?? true,
           showComments: data.respVisible ?? true,
         });

--- a/frontend/src/pages/mapaCurso/MapaCurso.tsx
+++ b/frontend/src/pages/mapaCurso/MapaCurso.tsx
@@ -295,6 +295,7 @@ export default function MapaCurso() {
 
           <section className="mapa-activities">
             {(loading || loadingCompletion) && <p className="mapa-feedback">Cargando actividades...</p>}
+            {actividadRows.length === 0 && temas.length === 0 && <p className="mapa-feedback">Todavía no hay temas creados.</p>}
             
             {!loading && !loadingCompletion && error && (
               <p className="mapa-feedback mapa-feedback--error">{error}</p>
@@ -303,6 +304,7 @@ export default function MapaCurso() {
             {selectedTema && !loading && !loadingCompletion && !error && (
               <>
                 <h2 className="mapa-activities-title">{selectedTema.titulo}</h2>
+                {actividadRows.length === 0 && temas.length > 0 && <p className="mapa-feedback">Todavía no hay actividades en este tema.</p>}
                 <ol className="mapa-activities-map" ref={mapContainerRef}>
                   {actividadRows.map((row, rowIndex) => {
                     const reverse = rowIndex % 2 === 1;


### PR DESCRIPTION
Se ha hecho un pequeño cambio para utilizar la propiedad que habilita el botón de ver respuestas correctas en el modal de resultado de actividad. Sigue sin ser lo mismo que "mostrar respuestas correctas" porque ese parámetro sigue sin habilitar el botón "ver solución", por lo que las funciones siguen quedando diferenciadas.