### PR TITLE
Fix/433 respuesta alumno cartas

### DIFF
--- a/backend/src/main/java/com/cerebrus/inscripcion/InscripcionController.java
+++ b/backend/src/main/java/com/cerebrus/inscripcion/InscripcionController.java
@@ -40,9 +40,9 @@ public class InscripcionController {
             
         } catch (RuntimeException e) {
             if (e.getMessage().equals("404 Not Found")) {
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body("El curso no existe");
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body("El curso no existe. Revisa que el código sea correcto");
             } else if (e.getMessage().equals("400 Bad Request")) {
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("El alumno ya está inscrito en este curso");
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Ya estás inscrito en este curso");
             } else if (e.getMessage().equals("403 Forbidden")) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).body("No puedes unirte a un curso no visible");
             } else if(e.getMessage().equals("401 Unauthorized")) {

--- a/backend/src/test/java/com/cerebrus/InscripccionTest/InscripcionControllerTest.java
+++ b/backend/src/test/java/com/cerebrus/InscripccionTest/InscripcionControllerTest.java
@@ -49,7 +49,7 @@ class InscripcionControllerTest {
         ResponseEntity<String> respuesta = controller.inscribirAlumno("NOPE");
 
         assertThat(respuesta.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
-        assertThat(respuesta.getBody()).isEqualTo("El curso no existe");
+        assertThat(respuesta.getBody()).isEqualTo("El curso no existe. Revisa que el código sea correcto");
     }
 
     @Test
@@ -59,7 +59,7 @@ class InscripcionControllerTest {
         ResponseEntity<String> respuesta = controller.inscribirAlumno("ABC123");
 
         assertThat(respuesta.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(respuesta.getBody()).isEqualTo("El alumno ya está inscrito en este curso");
+        assertThat(respuesta.getBody()).isEqualTo("Ya estás inscrito en este curso");
     }
 
     @Test

--- a/frontend/src/pages/cartaAlumno/CartaAlumno.tsx
+++ b/frontend/src/pages/cartaAlumno/CartaAlumno.tsx
@@ -200,7 +200,7 @@ export default function CartaAlumno() {
           showScore: cartaData.mostrarPuntuacion ?? true,
           allowRetry: cartaData.permitirReintento ?? false,
           showCorrectAnswer: cartaData.encontrarRespuestaMaestro ?? true,
-          showStudentAnswer: cartaData.encontrarRespuestaAlumno ?? true,
+          showStudentAnswer: false, // En esta actividad el profesor nunca puede marcar "Mostrar respuesta del alumno"
           showComments: cartaData.respVisible ?? true,
         });
 

--- a/frontend/src/pages/clasificacionAlumno/ClasificacionAlumno.css
+++ b/frontend/src/pages/clasificacionAlumno/ClasificacionAlumno.css
@@ -200,7 +200,7 @@
     padding: 0;
     box-sizing: border-box;
     align-content: flex-start;
-    overflow: hidden;
+    overflow: visible;
   }
 
   .clf-respuestas-asociadas .clf-runa-wrapper.small {

--- a/frontend/src/pages/marcarImagenAlumno/MarcarImagenAlumno.tsx
+++ b/frontend/src/pages/marcarImagenAlumno/MarcarImagenAlumno.tsx
@@ -497,6 +497,7 @@ export default function MarcarImagenAlumno() {
                           [selectedPunto.id]: e.target.value,
                         }))
                       }
+                      maxLength={80}
                       autoFocus
                     />
                   </div>

--- a/frontend/src/pages/misCursos/MisCursos.tsx
+++ b/frontend/src/pages/misCursos/MisCursos.tsx
@@ -60,22 +60,38 @@ export default function MisCursos() {
   }, [token]);
 
   const handleJoin = async () => {
-    const apiBase = (import.meta.env.VITE_API_URL ?? "").trim().replace(/\/$/, "");
     const codigo = codigoCurso.trim();
     if (!codigo) return;
     setJoinLoading(true);
     setJoinError(null);
     setJoinSuccess(null);
     try {
-      await apiFetch(
-        `${apiBase}/api/inscripciones/inscribe?codigoCurso=${encodeURIComponent(codigo)}`,  
-        { method: "POST" }
+      const response = await fetch(
+        `${apiBase}/api/inscripciones/inscribe?codigoCurso=${encodeURIComponent(codigo)}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+        }
       );
-      setJoinSuccess("¡Te has unido al curso correctamente!");
+
+      const rawBody = (await response.clone().text()).trim();
+
+      if (!response.ok) {
+        let message = rawBody;
+        if (!message || /^Error\s+\d{3}$/.test(message) || /^<!doctype\s+html/i.test(message) || /^<html/i.test(message)) {
+          message = "No se pudo realizar la inscripción al curso.";
+        }
+        throw new Error(message);
+      }
+
+      setJoinSuccess(rawBody || "¡Te has unido al curso correctamente!");
       setCodigoCurso("");
       await loadCursos();
-    } catch (error) {
-      setJoinError("No se pudo realizar la inscripción al curso. Revisa el código.");
+    } catch (e) {
+      setJoinError(e instanceof Error ? e.message : "No se pudo realizar la inscripción al curso.");
     } finally {
       setJoinLoading(false);
     }

--- a/frontend/src/pages/preguntaAbiertaAlumno/PreguntaAbiertaAlumno.css
+++ b/frontend/src/pages/preguntaAbiertaAlumno/PreguntaAbiertaAlumno.css
@@ -55,6 +55,7 @@
 
 .ta-open-input:focus {
   background-color: var(--color-accent-light);
+  color: #fff;
 }
 
 /* ── Responsive: apila columnas en móvil ── */

--- a/frontend/src/pages/preguntaAbiertaAlumno/PreguntaAbiertaAlumno.tsx
+++ b/frontend/src/pages/preguntaAbiertaAlumno/PreguntaAbiertaAlumno.tsx
@@ -322,6 +322,7 @@ export default function PreguntaAbiertaAlumno() {
                       setRespuestas(newMap);
                     }}
                     disabled={submitted || submitting}
+                    maxLength={1100}
                   />
                 </div>
 


### PR DESCRIPTION
Se han arreglado 2 incidencias:

- Se ha eliminado el botón de "Ver mi respuesta" tras completar una actividad de tipo carta (el profesor ni siquiera puede marcar "Mostrar respuesta del alumno" en la configuración de la actividad, por lo que ese botón era totalmente inútil).
- Se ha cambiado el procedimiento para enseñar mensajes de error al unirse a un curso, ahora se muestran los errores enviados por el controlador, que son más específicos ("El curso no existe", "El alumno ya está inscrito en este curso", "No puedes inscribirte a un curso no visible"...)

También se han incluido arreglos para otras incidencias menores